### PR TITLE
Potencia CT valor medio entre claves elija la menor

### DIFF
--- a/spec/utils_spec.py
+++ b/spec/utils_spec.py
@@ -12,6 +12,6 @@ with description('Searching the nearest element'):
             x = nearest(14, 1, 2, 3, 20, 40)
             expect(x).to(equal(20))
         with context('if the element is just in the middle between to values'):
-            with it('must return the greatest'):
+            with it('must return the lowest'):
                 x = nearest(35, 0, 30, 40)
-                expect(x).to(equal(40))
+                expect(x).to(equal(30))

--- a/spec/utils_spec.py
+++ b/spec/utils_spec.py
@@ -2,16 +2,21 @@ from expects import expect, equal
 from tipoinstalacion import nearest
 
 
-with description('Searching the nearest element'):
-    with context('if only one element is passed'):
+with description('Searching the nearest element.'):
+    with context('If only one element is passed'):
         with it('must return this element'):
             x = nearest(1, 10)
             expect(x).to(equal(10))
-    with context('if more elements are passed'):
-        with it('must return the nearest value'):
-            x = nearest(14, 1, 2, 3, 20, 40)
-            expect(x).to(equal(20))
-        with context('if the element is just in the middle between to values'):
+    with context('If more elements are passed.'):
+        with context('If it is the lowest between to values'):
+            with it('must return the lowest'):
+                x = nearest(14, 1, 2, 3, 20, 40)
+                expect(x).to(equal(20))
+        with context('If the element is just in the middle between to values'):
             with it('must return the lowest'):
                 x = nearest(35, 0, 30, 40)
                 expect(x).to(equal(30))
+        with context('If it is the greatest between to values'):
+            with it('must return the greatest'):
+                x = nearest(36, 0, 30, 40)
+                expect(x).to(equal(40))

--- a/tipoinstalacion/__init__.py
+++ b/tipoinstalacion/__init__.py
@@ -9,15 +9,20 @@ except Exception as e:
 def nearest(value, *values):
     """
     Get the nearest value from values.
-    That is, the highest key less than or equal to `value`.
-    If there is none, returns the lowest of the keys.
+    If there is a tie, returns the lowest of the keys.
 
     :param value: value to find
     :param values: list of values to return
     :return: the nearest value from values
     """
-    keys = sorted(values)
-    for k in reversed(keys):
-        if k <= value:
-            return k
-    return keys[0]
+    values = sorted(values)
+    best = values[0]
+    best_diff = abs(value - best)
+    for v in values[1:]:
+        diff = abs(value - v)
+        if diff < best_diff:
+            best = v
+            best_diff = diff
+        elif diff == best_diff and v < best:
+            best = v  # breaks draw in favor of the floor value
+    return best

--- a/tipoinstalacion/__init__.py
+++ b/tipoinstalacion/__init__.py
@@ -8,18 +8,16 @@ except Exception as e:
 
 def nearest(value, *values):
     """
-    Get the nearest value from values
+    Get the nearest value from values.
+    That is, the highest key less than or equal to `value`.
+    If there is none, returns the lowest of the keys.
+
     :param value: value to find
     :param values: list of values to return
     :return: the nearest value from values
     """
-    ant_diff = None
-    values = list(sorted(values))
-    for idx, v in enumerate(values):
-        diff = abs(value - v)
-        if diff == 0:
-            return v
-        elif ant_diff is not None and diff > ant_diff:
-            return values[idx - 1]
-        ant_diff = diff
-    return v
+    keys = sorted(values)
+    for k in reversed(keys):
+        if k <= value:
+            return k
+    return keys[0]


### PR DESCRIPTION
# Objetivo

Cuando la potencia del CT (total) sea un valor medio entre dos claves, la elección del valor se decante siempre por el menor de las claves.

Por ejemplo, Cuando llegaba un valor de potencia 75 debía elegir entre las claves 50 y 100. Antes elegía la 100. Ahora se quiere la 50.

# Elemento afectado
CT